### PR TITLE
A GitHub Action to lint Python code

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,0 +1,18 @@
+name: lint_python
+on:
+  pull_request:
+  push:
+  #  branches: [master]
+jobs:
+  lint_python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-python@master
+      - run: pip install black codespell flake8 isort pytest
+      - run: black . --diff || true
+      - run: codespell --quiet-level=2 || true  # --ignore-words-list="" --skip=""
+      - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+      - run: isort --recursive . || true
+      - run: pip install -r requirements.txt || true
+      - run: pytest . || true

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/setup-python@master
       - run: pip install black codespell flake8 isort pytest
       - run: black . --diff || true
-      - run: codespell --quiet-level=2 || true  # --ignore-words-list="" --skip=""
+      - run: codespell --quiet-level=2  # --ignore-words-list="" --skip=""
       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
       - run: isort --recursive . || true
       - run: pip install -r requirements.txt || true

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Also provides convenience state-specific properties (`began` etc.).
   * `number_of_touches_required` - Set if more than one finger is
     required for the gesture to be recognized.
   * `minimum_press_duration` - Set to change the default 0.5-second
-    recognition treshold.
+    recognition threshold.
   * `allowable_movement` - Set to change the default 10 point maximum
   distance allowed for the gesture to be recognized.
 

--- a/gestures.py
+++ b/gestures.py
@@ -347,7 +347,7 @@ def long_press(view, action,
     * `number_of_touches_required` - Set if more than one finger is
       required for the gesture to be recognized.
     * `minimum_press_duration` - Set to change the default 0.5-second
-      recognition treshold.
+      recognition threshold.
     * `allowable_movement` - Set to change the default 10 point maximum
     distance allowed for the gesture to be recognized.
     """


### PR DESCRIPTION
https://github.com/cclauss/pythonista-gestures/actions
$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./pygestures.py:632:19: F821 undefined name 'copy'
      self.data = copy.deepcopy(data)
                  ^
```
https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python a __NameError__ is raised which will halt/crash the script on the user.